### PR TITLE
semantic logging colors with response info

### DIFF
--- a/generated/server/app/configure/app-variables.js
+++ b/generated/server/app/configure/app-variables.js
@@ -12,6 +12,7 @@ var env = require(path.join(rootPath, './server/env'));
 
 var logMiddleware = function (req, res, next) {
     function logReq (req) {
+        console.log(chalk.gray('\n' + new Date().toString()));
         console.log(chalk.underline(util.format('%s: %s %s', 'REQUEST  ', req.method, req.path)));
         console.log(util.format('%s: %s', 'QUERY    ', util.inspect(req.query)));
         console.log(util.format('%s: %s', 'BODY     ', util.inspect(req.body)));
@@ -24,16 +25,17 @@ var logMiddleware = function (req, res, next) {
             /* status code  >= 200 */ 'green';
         console.log(util.format('%s: ' + chalk[statusColor]('%s %s ') + chalk.gray('(%s ms)'), 'RESPONSE ', res.statusCode, http.STATUS_CODES[res.statusCode]), diff);
     }
+    function msDiff (time) {
+        var diff = process.hrtime(time);
+        // calculates diff in milliseconds, rounded to two decimals
+        return Math.round((diff[0] * 1e3 + diff[1] / 1e6) * 100) / 100;
+    }
     // composing it all together by attaching to res finish event
     var time = process.hrtime();
     res.on('finish', function(){
-        console.log(chalk.gray('\n' + new Date().toString()));
         // if req log is not deferred to res end, other req/res logs can occur
         logReq(req);
-        // reducing diff array to time elapsed in milliseconds, 2 decimals max
-        var diff = process.hrtime(time);
-        diff = Math.round((diff[0] * 1e3 + diff[1] / 1e6) * 100) / 100;
-        logRes(res, diff);
+        logRes(res, msDiff(time));
     });
     // not handling `close` event (connection terminates without proper `end`)
     next();

--- a/generated/server/app/configure/app-variables.js
+++ b/generated/server/app/configure/app-variables.js
@@ -45,8 +45,11 @@ var logMiddleware = function (req, res, next) {
         // padding to separate from next cycle
         console.log();
     });
-    // not handling `close` event (connection terminates without proper `end`)
-
+    res.on('close', function(){
+        logReq(req);
+        console.log(chalk.red('CONNECTION CLOSED BEFORE RES END/FLUSH\n'));
+    });
+    
     next();
 };
 

--- a/generated/server/app/configure/app-variables.js
+++ b/generated/server/app/configure/app-variables.js
@@ -11,12 +11,14 @@ var faviconPath = path.join(rootPath, './server/app/views/favicon.ico');
 var env = require(path.join(rootPath, './server/env'));
 
 var logMiddleware = function (req, res, next) {
+
     function logReq (req) {
         console.log(chalk.gray('\n' + new Date().toString()));
         console.log(chalk.underline(util.format('%s: %s %s', 'REQUEST  ', req.method, req.path)));
         console.log(util.format('%s: %s', 'QUERY    ', util.inspect(req.query)));
         console.log(util.format('%s: %s', 'BODY     ', util.inspect(req.body)));
     }
+
     function logRes (res, diff) {
         var statusColor =
             (res.statusCode >= 500) ? 'red' :
@@ -25,11 +27,13 @@ var logMiddleware = function (req, res, next) {
             /* status code  >= 200 */ 'green';
         console.log(util.format('%s: ' + chalk[statusColor]('%s %s ') + chalk.gray('(%s ms)'), 'RESPONSE ', res.statusCode, http.STATUS_CODES[res.statusCode]), diff);
     }
+
     function msDiff (time) {
         var diff = process.hrtime(time);
         // calculates diff in milliseconds, rounded to two decimals
         return Math.round((diff[0] * 1e3 + diff[1] / 1e6) * 100) / 100;
     }
+
     // composing it all together by attaching to res finish event
     var time = process.hrtime();
     res.on('finish', function(){
@@ -38,6 +42,7 @@ var logMiddleware = function (req, res, next) {
         logRes(res, msDiff(time));
     });
     // not handling `close` event (connection terminates without proper `end`)
+
     next();
 };
 

--- a/generated/server/app/configure/app-variables.js
+++ b/generated/server/app/configure/app-variables.js
@@ -20,12 +20,14 @@ var logMiddleware = function (req, res, next) {
     }
 
     function logRes (res, diff) {
+        var status = res.statusCode;
+        var meaning = http.STATUS_CODES[status];
         var statusColor =
-            (res.statusCode >= 500) ? 'red' :
-            (res.statusCode >= 400) ? 'yellow' :
-            (res.statusCode >= 300) ? 'cyan' :
-            /* status code  >= 200 */ 'green';
-        console.log(util.format('%s: ' + chalk[statusColor]('%s %s ') + chalk.gray('(%s ms)'), 'RESPONSE ', res.statusCode, http.STATUS_CODES[res.statusCode]), diff);
+            (status >= 500) ? 'red' :
+            (status >= 400) ? 'yellow' :
+            (status >= 300) ? 'cyan' :
+            /* code >= 200 */ 'green';
+        console.log(util.format('RESPONSE : ' + chalk[statusColor]('%s %s ') + chalk.gray('(%s ms)'), status, meaning, diff));
     }
 
     function msDiff (time) {

--- a/generated/server/app/configure/app-variables.js
+++ b/generated/server/app/configure/app-variables.js
@@ -13,7 +13,7 @@ var env = require(path.join(rootPath, './server/env'));
 var logMiddleware = function (req, res, next) {
 
     function logReq (req) {
-        console.log(chalk.gray('\n' + new Date().toString()));
+        console.log(chalk.gray(new Date().toString()));
         console.log(chalk.underline(util.format('%s: %s %s', 'REQUEST  ', req.method, req.path)));
         console.log(util.format('%s: %s', 'QUERY    ', util.inspect(req.query)));
         console.log(util.format('%s: %s', 'BODY     ', util.inspect(req.body)));
@@ -40,6 +40,8 @@ var logMiddleware = function (req, res, next) {
         // if req log is not deferred to res end, other req/res logs can occur
         logReq(req);
         logRes(res, msDiff(time));
+        // padding to separate from next cycle
+        console.log();
     });
     // not handling `close` event (connection terminates without proper `end`)
 


### PR DESCRIPTION
As cheery as they were, the multicolor req-res logs were not very meaningful. Changed to use grayed-out timestamps / interval measurements, underlined request row, and semantically-colored response status code + meaning.

Formatting is a very subjective and personal thing. Feel very welcome to adapt or adjust as you wish.

Functional note: because of the delay between requests and responses, there is some question as to whether req should be logged immediately and res on close, or both req and res logged on close. The former is more accurate, but if other requests occur in the meantime, the connection between a given req and res becomes very difficult to indicate / perceive at a glance. The latter keeps all the info in one place, but that means requests will be logged only following any logs that they trigger (e.g. in routes).

Also, in addition to a res ending properly (`finish` event), a res can end improperly (`close` event). ~~This logger doesn't do anything in the latter case as of this PR.~~

![logging](https://cloud.githubusercontent.com/assets/7230206/7384988/f1d16a20-ee0a-11e4-8a68-23d726f39ce9.png)