### PR TITLE
nodemon with specificity

### DIFF
--- a/generated/package.json
+++ b/generated/package.json
@@ -4,7 +4,7 @@
   "description": "A generated project at Fullstack Academy",
   "main": "server/start.js",
   "scripts": {
-    "start": "node server/start.js",
+    "start": "nodemon --watch server -e js,html server/start.js",
     "postinstall": "./node_modules/bower/bin/bower install && gulp build"
   },
   "dependencies": {
@@ -40,6 +40,7 @@
     "mocha-mongoose": "^1.0.3",
     "mongodb": "^1.4.33",
     "mongoose": "3.8.23",
+    "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",
     "passport-google-oauth": "^0.1.5",


### PR DESCRIPTION
`--watch server` so it only restarts if server directory files change.

`-e js,html` so it restarts if scripts or templates/partials change.

Added as a dependency.

*NOTE*: consider using [`gulp-nodemon`](https://github.com/JacksonGariety/gulp-nodemon) in the future? Then everything can just be handled with `gulp`.