### PR TITLE
updated mongoose to 4.0.2

### DIFF
--- a/generated/package.json
+++ b/generated/package.json
@@ -39,7 +39,7 @@
     "lodash": "^3.3.0",
     "mocha-mongoose": "^1.0.3",
     "mongodb": "^1.4.33",
-    "mongoose": "3.8.23",
+    "mongoose": "4.0.2",
     "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",


### PR DESCRIPTION
Mongoose 4.0.2 is stable and `save` now returns a promise. Tested and it seemed to work fine in fsg.

This is my smallest PR ever.