### PR TITLE
added some test globals

### DIFF
--- a/generated/.jshintrc
+++ b/generated/.jshintrc
@@ -14,10 +14,14 @@
   "undef" : true,
   "browser": true,
   "laxbreak": true,
+  "mocha": true,
   "globals" : {
     "angular" : true,
     "app": true,
     "io": true,
-    "_": true
+    "_": true,
+    "inject": true,
+    "expect": true,
+    "sinon": true
   }
 }


### PR DESCRIPTION
It annoyed me that `beforeEach`, `sinon`, `expect` etc. were all being flagged by the hinter. Added a few lines to the `.jshintrc` file to compensate.