### PR TITLE
update mongoose to stable release: 4.0.1 (fix to undefined length bug)

### DIFF
--- a/generated/package.json
+++ b/generated/package.json
@@ -42,7 +42,7 @@
     "lodash": "^3.9.3",
     "mocha-mongoose": "^1.0.3",
     "mongodb": "^1.4.33",
-    "mongoose": "3.8.23",
+    "mongoose": "4.0.1",
     "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",


### PR DESCRIPTION
Hey Joe,

Feel free to experiment with / disregard this.  For me, every time I run fsg I have to update mongoose to 4.0.1.  The mongoose version packaged with fsg does say "this is an unstable release (yada yada)" and I always get:

```
TypeError: Cannot read property 'length' of undefined
    at processResults (/Users/my_name/my_project/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1581:31)
```