### PR TITLE
Update to navbar.scss

### DIFF
--- a/generated/browser/scss/directives/navbar.scss
+++ b/generated/browser/scss/directives/navbar.scss
@@ -6,7 +6,8 @@ navbar {
   box-shadow: 1px 1px 14px -3px black;
 
   .container {
-    width: 1340px;
+    width: 100%;
+    max-width: 1340px;
     padding-top: 20px;
   }
 

--- a/generated/browser/scss/directives/navbar.scss
+++ b/generated/browser/scss/directives/navbar.scss
@@ -6,7 +6,7 @@ navbar {
   box-shadow: 1px 1px 14px -3px black;
 
   .container {
-    width: 100%;
+    width: 91%;
     max-width: 1340px;
     padding-top: 20px;
   }


### PR DESCRIPTION
- modified width to 100% and added a max-width of 1340px on navbar .container
  - width of 1340px on navbar .container caused login/logout to overflow to the right on screen resolutions less than 1340px in width