### PR TITLE
karma config fix

### DIFF
--- a/generated/tests/browser/karma.conf.js
+++ b/generated/tests/browser/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
         'node_modules/lodash/index.js',
         'node_modules/angular/angular.js',
         'node_modules/angular-ui-router/release/angular-ui-router.js',
-        'node_modules/angular-bootstrap/dist/ui-bootstrap.js',
+        'node_modules/angular-bootstrap/ui-bootstrap.js',
         'node_modules/socket.io-client/socket.io.js',
         'public/main.js',
         'node_modules/sinon/pkg/sinon.js',


### PR DESCRIPTION
`angular-bootstrap` doesn't seem to keep their production `npm` files in a `dist` folder anymore. I was getting some errors when trying to test my module that required `ui-bootstrap` and this fixed them (after a gulp restart!). Hopefully will save some headaches with Angular testing.