### PR TITLE
changed  CALLBACK_URL to GOOGLE_CALLBACK_URL (line 25 in production.js)

### DIFF
--- a/generated/server/env/production.js
+++ b/generated/server/env/production.js
@@ -22,6 +22,6 @@ module.exports = {
     "GOOGLE": {
         "clientID": process.env.GOOGLE_CLIENT_ID,
         "clientSecret": process.env.GOOGLE_CLIENT_SECRET,
-        "callbackURL": process.env.CALLBACK_URL
+        "callbackURL": process.env.GOOGLE_CALLBACK_URL
     }
 };


### PR DESCRIPTION
Hi! 

Changed callback url on process.env (line 25 in production.js) to:

 "callbackURL": process.env.GOOGLE_CALLBACK_URL

(originally was  "callbackURL": process.env.CALLBACK_URL)