### PR TITLE
Hotfix for mongoose

### DIFF
--- a/generated/package.json
+++ b/generated/package.json
@@ -51,7 +51,7 @@
     "lodash": "^3.9.3",
     "mocha-mongoose": "^1.0.3",
     "mongodb": "^1.4.33",
-    "mongoose": "^4.0.7",
+    "mongoose": "4.0.7",
     "nodemon": "^1.3.7",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",


### PR DESCRIPTION
FSG breaks with the latest version of mongoose, this PR changes the package.json so that it won't break.