### PR TITLE
Sourcemap Sass

### DIFF
--- a/generated/gulpfile.js
+++ b/generated/gulpfile.js
@@ -93,7 +93,9 @@ gulp.task('buildCSS', function () {
         .pipe(plumber({
             errorHandler: notify.onError('SASS processing failed! Check your gulp process.')
         }))
+        .pipe(sourcemaps.init())
         .pipe(sassCompilation)
+        .pipe(sourcemaps.write())
         .pipe(rename('style.css'))
         .pipe(gulp.dest('./public'));
 });


### PR DESCRIPTION
@joedotjs 
For chrome dev console to show which Sass file is the culprit for styles.
<img width="342" alt="screen shot 2016-04-20 at 5 48 35 pm" src="https://cloud.githubusercontent.com/assets/6380769/14691922/f20a9288-0721-11e6-9a99-f3cd4bbc4534.png">

Currently, it shows the line number in the compiled CSS, which isn't that helpful.

![image](https://cloud.githubusercontent.com/assets/6380769/14691978/3a37995c-0722-11e6-93c5-3030707a72d0.png)
