### PR TITLE
Hotfix for MongoLab env variable on deployment

### DIFF
--- a/generated/server/env/production.js
+++ b/generated/server/env/production.js
@@ -7,7 +7,7 @@
  */
 
 module.exports = {
-    "DATABASE_URI": process.env.MONGOLAB_URI,
+    "DATABASE_URI": process.env.MONGODB_URI,
     "SESSION_SECRET": process.env.SESSION_SECRET,
     "TWITTER": {
         "consumerKey": process.env.TWITTER_CONSUMER_KEY,


### PR DESCRIPTION
Running `heroku addons:create mongolab` results in a production environment variable of `MONGODB_URI`, not `MONGOLAB_URI`