### PR TITLE
Safer generate

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -9,7 +9,7 @@ ncp.limit = 16;
 var newProjectDir = (function () {
 
     if (process.argv[2]) {
-        return path.join(process.cwd(), process.argv[2]);
+        return path.resolve(process.cwd(), process.argv[2]);
     }
 
     return process.cwd();

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -12,7 +12,7 @@ var newProjectDir = (function () {
         return path.resolve(process.cwd(), process.argv[2]);
     }
 
-    return path.join(process.cwd(), 'fsg');
+    return path.join(process.cwd(), 'generated');
 
 })();
 

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -12,7 +12,7 @@ var newProjectDir = (function () {
         return path.resolve(process.cwd(), process.argv[2]);
     }
 
-    return process.cwd();
+    return path.join(process.cwd(), 'fsg');
 
 })();
 


### PR DESCRIPTION
Closes #52 more aggressively and extends work from 594104be4.

Using `path.resolve` instead of `path.join` means that if someone tries to do, say, `fsg /Users/glebec/Dev/projects/newproject`, it will correctly follow the absolute path instead of try to make a sub-path of the current working directory. It will still work for normal relative paths, e.g. `fsg newproject` will generate in the `newproject` subdir of the current working dir.

Defaulting to placing files in an `fsg` sub-directory prevents ever accidentally placing files in the current working directory (which may be counter to some people's intuition). While others may be surprised at this behavior (expecting the files to be generated in the current working directory), this way is ultimately safer; it is easier to fix the contents being one level down (or even re-generate), than it is to clean up accidentally placing files inside a directory which may already have contents.

You can still do `fsg .` to generate in the current directory.

If this goes through I will edit the Wiki accordingly.