### PR TITLE
Define user model directly by pulling in _db

### DIFF
--- a/generated/server/db/index.js
+++ b/generated/server/db/index.js
@@ -2,5 +2,5 @@
 var db = require('./_db');
 module.exports = db;
 
-require('./models/user')(db);
+var User = require('./models/user');
 

--- a/generated/server/db/models/user.js
+++ b/generated/server/db/models/user.js
@@ -3,58 +3,53 @@ var crypto = require('crypto');
 var _ = require('lodash');
 var Sequelize = require('sequelize');
 
-module.exports = function (db) {
+var db = require('../_db');
 
-    db.define('user', {
-        email: {
-            type: Sequelize.STRING
+module.exports = db.define('user', {
+    email: {
+        type: Sequelize.STRING
+    },
+    password: {
+        type: Sequelize.STRING
+    },
+    salt: {
+        type: Sequelize.STRING
+    },
+    twitter_id: {
+        type: Sequelize.STRING
+    },
+    facebook_id: {
+        type: Sequelize.STRING
+    },
+    google_id: {
+        type: Sequelize.STRING
+    }
+}, {
+    instanceMethods: {
+        sanitize: function () {
+            return _.omit(this.toJSON(), ['password', 'salt']);
         },
-        password: {
-            type: Sequelize.STRING
-        },
-        salt: {
-            type: Sequelize.STRING
-        },
-        twitter_id: {
-            type: Sequelize.STRING
-        },
-        facebook_id: {
-            type: Sequelize.STRING
-        },
-        google_id: {
-            type: Sequelize.STRING
+        correctPassword: function (candidatePassword) {
+            return this.Model.encryptPassword(candidatePassword, this.salt) === this.password;
         }
-    }, {
-        instanceMethods: {
-            sanitize: function () {
-                return _.omit(this.toJSON(), ['password', 'salt']);
-            },
-            correctPassword: function (candidatePassword) {
-                return this.Model.encryptPassword(candidatePassword, this.salt) === this.password;
-            }
+    },
+    classMethods: {
+        generateSalt: function () {
+            return crypto.randomBytes(16).toString('base64');
         },
-        classMethods: {
-            generateSalt: function () {
-                return crypto.randomBytes(16).toString('base64');
-            },
-            encryptPassword: function (plainText, salt) {
-                var hash = crypto.createHash('sha1');
-                hash.update(plainText);
-                hash.update(salt);
-                return hash.digest('hex');
-            }
-        },
-        hooks: {
-            beforeValidate: function (user) {
-                if (user.changed('password')) {
-                    user.salt = user.Model.generateSalt();
-                    user.password = user.Model.encryptPassword(user.password, user.salt);
-                }
+        encryptPassword: function (plainText, salt) {
+            var hash = crypto.createHash('sha1');
+            hash.update(plainText);
+            hash.update(salt);
+            return hash.digest('hex');
+        }
+    },
+    hooks: {
+        beforeValidate: function (user) {
+            if (user.changed('password')) {
+                user.salt = user.Model.generateSalt();
+                user.password = user.Model.encryptPassword(user.password, user.salt);
             }
         }
-    });
-
-
-
-};
-
+    }
+});


### PR DESCRIPTION
Closes #55.

Furthermore, I'm seeing a frequent accident where people will do something like `require('./path/to/some/model/definition/')(db)`, which will **redefine** the model that gets required. This means its associations fail to get established. This bug can be hard to find when other code accesses the given model via `db.model('nameOfModel')`, because code *over there* may have the correct associations.

The approach in this PR also fixes that problem.