### PR TITLE
enable pg-native for faster database

### DIFF
--- a/generated/package.json
+++ b/generated/package.json
@@ -57,6 +57,7 @@
     "passport-twitter": "^1.0.2",
     "pg": "^4.5.5",
     "pg-hstore": "^2.3.2",
+    "pg-native": "^1.10.0",
     "run-sequence": "^1.0.2",
     "sequelize": "^3.23.3",
     "serve-favicon": "^2.2.0",

--- a/generated/server/db/_db.js
+++ b/generated/server/db/_db.js
@@ -2,6 +2,9 @@ var path = require('path');
 var Sequelize = require('sequelize');
 
 var env = require(path.join(__dirname, '../env'));
-var db = new Sequelize(env.DATABASE_URI, { logging: env.LOGGING });
+var db = new Sequelize(env.DATABASE_URI, {
+  logging: env.LOGGING,
+  native: env.NATIVE
+});
 
 module.exports = db;

--- a/generated/server/env/development.js
+++ b/generated/server/env/development.js
@@ -16,5 +16,6 @@ module.exports = {
     "clientSecret": "INSERT_GOOGLE_CLIENT_SECRET_HERE",
     "callbackURL": "INSERT_GOOGLE_CALLBACK_HERE"
   },
-  "LOGGING": true
+  "LOGGING": true,
+  "NATIVE": true
 };

--- a/generated/server/env/production.js
+++ b/generated/server/env/production.js
@@ -24,5 +24,6 @@ module.exports = {
         "clientSecret": process.env.GOOGLE_CLIENT_SECRET,
         "callbackURL": process.env.GOOGLE_CALLBACK_URL
     },
-    "LOGGING": true
+    "LOGGING": true,
+    "NATIVE": true
 };

--- a/generated/server/env/testing.js
+++ b/generated/server/env/testing.js
@@ -16,5 +16,6 @@ module.exports = {
     "clientSecret": "INSERT_GOOGLE_CLIENT_SECRET_HERE",
     "callbackURL": "INSERT_GOOGLE_CALLBACK_HERE"
   },
-  "LOGGING": false
+  "LOGGING": false,
+  "NATIVE": true
 };


### PR DESCRIPTION
The `pg-native` package uses C bindings over the pure-JS `pg` package. This results in significant performance improvements.