### PR TITLE
Updated user hooks for updating password

### DIFF
--- a/generated/server/db/models/user.js
+++ b/generated/server/db/models/user.js
@@ -45,7 +45,11 @@ module.exports = db.define('user', {
         }
     },
     hooks: {
-        beforeValidate: function (user) {
+        beforeCreate: function (user) {
+            user.salt = user.Model.generateSalt();
+            user.password = user.Model.encryptPassword(user.password, user.salt);
+        },
+        beforeUpdate: function (user) {
             if (user.changed('password')) {
                 user.salt = user.Model.generateSalt();
                 user.password = user.Model.encryptPassword(user.password, user.salt);


### PR DESCRIPTION
@omriBernstein: We ran into this during Grace Shopper multiple times and this is our fix.

Currently, the user model provided by FSG includes a `beforeValidate` hook that will hash the new password with a newly generated salt.

Unfortunately, Sequelize is weird, and validation actually runs **twice** on an `update` (or `save`), once before the hooks and once after the hooks. This means that while the hook is a `beforeValidate` hook, it will also run twice, first with the plaintext password the user is hoping to change it to, and again with the new hashed password. So what ends up being saved in the database is not the hash of the plaintext password, but the hash of the hash of the plaintext password.

The solution is to break up the hook into two: a `beforeCreate` and a `beforeUpdate`.
They share almost the exact same logic, but will only run once in their respective scenarios, ensuring password resets will now work properly.