### PR TITLE
Fixed beforeCreate hook for user

### DIFF
--- a/generated/server/db/models/user.js
+++ b/generated/server/db/models/user.js
@@ -46,8 +46,10 @@ module.exports = db.define('user', {
     },
     hooks: {
         beforeCreate: function (user) {
-            user.salt = user.Model.generateSalt();
-            user.password = user.Model.encryptPassword(user.password, user.salt);
+            if (user.changed('password')) {
+                user.salt = user.Model.generateSalt();
+                user.password = user.Model.encryptPassword(user.password, user.salt);
+            }
         },
         beforeUpdate: function (user) {
             if (user.changed('password')) {


### PR DESCRIPTION
I fixed a thing that broke another thing...

When I updated the hooks before, I did not include the condition to only encrypt the password if the user has input a password for account creation. Unfortunately, this did not account for OAuth and the possibility of a user being created without a password.

When that happens currently, the creation process errors out because `User.encryptPassword` expects a plainText password, and it's being passed null/undefined when signing up with OAuth, and the error states that `Data must be a string or buffer`.

By adding the conditional, everything is in working order.