### PR TITLE
Remove session id from client

### DIFF
--- a/generated/browser/js/fsa/fsa-pre-built.js
+++ b/generated/browser/js/fsa/fsa-pre-built.js
@@ -51,10 +51,10 @@
     app.service('AuthService', function ($http, Session, $rootScope, AUTH_EVENTS, $q) {
 
         function onSuccessfulLogin(response) {
-            var data = response.data;
-            Session.create(data.id, data.user);
+            var user = response.data.user;
+            Session.create(user);
             $rootScope.$broadcast(AUTH_EVENTS.loginSuccess);
-            return data.user;
+            return user;
         }
 
         // Uses the session factory to see if an
@@ -115,16 +115,13 @@
             self.destroy();
         });
 
-        this.id = null;
         this.user = null;
 
         this.create = function (sessionId, user) {
-            this.id = sessionId;
             this.user = user;
         };
 
         this.destroy = function () {
-            this.id = null;
             this.user = null;
         };
 

--- a/generated/tests/browser/fsa-prebuilt/auth-service-test.js
+++ b/generated/tests/browser/fsa-prebuilt/auth-service-test.js
@@ -26,7 +26,7 @@ describe('AuthService', function () {
     describe('isAuthenicated', function () {
 
         it('should return true if a Session exists', function () {
-            Session.create('testID', {email: 'cool@gmail.com'});
+            Session.create({email: 'cool@gmail.com'});
             expect(AuthService.isAuthenticated()).to.be.ok;
         });
 
@@ -41,7 +41,7 @@ describe('AuthService', function () {
 
         it('should return the user from the Session if already authenticated', function (done) {
             var x = {};
-            Session.create('testID', x);
+            Session.create(x);
             AuthService.getLoggedInUser().then(function (user) {
                 expect(user).to.be.equal(x);
                 done();
@@ -257,7 +257,7 @@ describe('AuthService', function () {
 
         it('should destroy the session', function (done) {
 
-            Session.create('testID', { email: 'obama@gmai.com' });
+            Session.create({ email: 'obama@gmai.com' });
 
             AuthService.logout().then(function () {
                 expect(Session.user).to.be.equal(null);


### PR DESCRIPTION
@joedotjs I noticed today that the "onSuccessfulLogin" function in fsa-pre-built.js was expecting the response.data to include a .id property. The corresponding route (post requests to "/login" responds with a body that includes only a .user property. This PR removes references to the session ID in the client-side code. An alternative approach would be to change the route on the server side so it serves up the session ID.