### PR TITLE
Setting eslintrc as root

### DIFF
--- a/generated/.eslintrc.json
+++ b/generated/.eslintrc.json
@@ -1,5 +1,6 @@
 // http://eslint.org/docs/rules/
 {
+  "root": true,
   "extends": "fullstack", // from the `eslint-config-fullstack` npm module,
   "env": {
     "es6": true,


### PR DESCRIPTION
Setting an `esltinrc` as root means ESLint won't look in any higher directory for rules. This keeps linting project-specific, so the only rules that apply are the ones the team agrees on — also prevents bugs e.g. if a student accidentally has a broken `eslintrc` somewhere in their hard drive.