### PR TITLE
Split production and dev linting

### DIFF
--- a/generated/.eslintrc.json
+++ b/generated/.eslintrc.json
@@ -12,7 +12,8 @@
   },
   "rules": {
     "global-require": 0, // 0 = off, 1 = warn (yellow), 2 = error (red)
-    "camelcase": 0
+    "camelcase": 0,
+    "no-debugger": 1
     // add more rules here to override the fullstack config
   }
 }

--- a/generated/gulpfile.js
+++ b/generated/gulpfile.js
@@ -109,6 +109,22 @@ gulp.task('buildCSS', function () {
 // Production tasks
 // --------------------------------------------------------------
 
+gulp.task('lintJSProduction', function () {
+
+    return gulp.src(['./browser/js/**/*.js', './server/**/*.js'])
+        .pipe(plumber({
+            errorHandler: notify.onError('Linting FAILED! Check your gulp process.')
+        }))
+        .pipe(eslint({
+            rules: {
+                'no-debugger': 2 // 1 in dev
+            }
+        }))
+        .pipe(eslint.format())
+        .pipe(eslint.failOnError());
+
+});
+
 gulp.task('buildCSSProduction', function () {
     return gulp.src('./browser/scss/main.scss')
         .pipe(sass())


### PR DESCRIPTION
Closes #73.

Note that using separate `.eslintrc` files wasn't the way to go, as specifying a config file via the CLI breaks the hierarchy system. Instead I opted for an override in the existing config, plus inline rule changes in the gulpfile, which is… meh, but ok.

Also — I added a `lintJSProduction` task, but it's not currently used in any production workflow. @joedotjs maybe we should either include it as a dependency to another task, or else take it out? Or we can leave it in just in case we want to use it in the future.